### PR TITLE
Fix pgm_read_ptr() return type

### DIFF
--- a/cores/industruino/avr/pgmspace.h
+++ b/cores/industruino/avr/pgmspace.h
@@ -103,7 +103,7 @@ typedef const void* uint_farptr_t;
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #define pgm_read_float(addr) (*(const float *)(addr))
-#define pgm_read_ptr(addr) (*(const void *)(addr))
+#define pgm_read_ptr(addr) (*(void *const *)(addr))
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)


### PR DESCRIPTION
Hi,

This PR changes the return type of the `pgm_read_ptr()` macro to `void*`.
Without this fix, any attempts to use this macro causes the following error:

> error: 'const void*' is not a pointer-to-object type

Related issues:

* Same as arduino/ArduinoCore-API#118
* Fixes bblanchon/ArduinoJson#1519

Best regards,
Benoit